### PR TITLE
feat: open & handle sessions automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: 
+on:
   push:
    branches:
     - master
@@ -18,6 +18,7 @@ jobs:
       - run: |
           npm ci
           npm run lint
+          npm run docker
           npm test
 
   automerge:

--- a/README.md
+++ b/README.md
@@ -7,15 +7,13 @@ RavenDB plugin for Fastify. Internally it uses the official [ravendb](https://gi
 
 ## Table of contents
 
-- [fastify-ravendb](#fastify-ravendb)
-  - [Table of contents](#table-of-contents)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Examples](#examples)
-  - [Name option](#name-option)
-  - [Docker](#docker)
-  - [Testing](#testing)
-  - [License](#license)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Name option](#name-option)
+- [Docker](#docker)
+- [Testing](#testing)
+- [License](#license)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ RavenDB plugin for Fastify. Internally it uses the official [ravendb](https://gi
 
 ## Table of contents
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Basic example](#basic-example)
-- [Advanced examples](#advanced-examples)
-- [Name option](#name-option)
-- [Docker](#docker)
-- [License](#license)
+- [fastify-ravendb](#fastify-ravendb)
+  - [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Examples](#examples)
+  - [Name option](#name-option)
+  - [Docker](#docker)
+  - [Testing](#testing)
+  - [License](#license)
 
 ## Installation
 
@@ -23,29 +25,45 @@ npm i fastify-ravendb
 
 ## Usage
 
-Register it as any other Fastify plugin. It will add the `rvn` (same name as RavenDB's CLI tool) namespace to your Fastify instance. You can access and use it the same as you would do with any `DocumentStore` instance from the official RavenDB Node.js client.
+Register it as any other Fastify plugin. It will decorate your Fastify instance with the `rvn` (same name as RavenDB's CLI tool) object, and you can access and use it the same as you would do with any `DocumentStore` instance from the official RavenDB Node.js client.
+
+Once the plugin is registered you can also enable automatic session handling for specific routes, via the `rvn.autoSession` route option. Sessions will be automatically open in the `onRequest` hook, requests will be decorated with the `rvn` object (the session, which you can use as with any session from the official client), and any pending changes will be saved `onResponse`.
+
+### Plugin options
 
 You can pass the following options when registering the plugin (all of them are optional unless stated otherwise):
 
 | Parameter | Example | Description |
 | --- | --- | --- |
-| `name` | `db1` | Specific name for the `DocumentStore` instance. Please check [Name option](#name-option) for more information.
-| `url` (required) | `http://live-test.ravendb.net` | RavenDB server URL. Same as in [ravendb#getting-started](https://github.com/ravendb/ravendb-nodejs-client#getting-started).
-| `databaseName` (required) | `test` | Database name. Same as in [ravendb#getting-started](https://github.com/ravendb/ravendb-nodejs-client#getting-started).
+| `name` | `'db1'` | Specific name for the `DocumentStore` instance. Please check [Name option](#name-option) for more information.
+| `url` (required) | `'http://live-test.ravendb.net'` | RavenDB server URL. Same as in [ravendb#getting-started](https://github.com/ravendb/ravendb-nodejs-client#getting-started).
+| `databaseName` (required) | `'test'` | Database name. Same as in [ravendb#getting-started](https://github.com/ravendb/ravendb-nodejs-client#getting-started).
 | `authOptions` | `{ certificate: fs.readFileSync(certificate), type: 'pem' }` | Authentication options (i.e. certificate and password). Same as in [ravendb#working-with-secured-server](https://github.com/ravendb/ravendb-nodejs-client#working-with-secured-server).
 | `findCollectionNameForObjectLiteral` | `e => e._collection` | A function to extract the target collection from an object literal entity. Same as in [ravendb#using-object-literals-for-entities](https://github.com/ravendb/ravendb-nodejs-client#using-object-literals-for-entities).
 
-## Basic example
+### Route options
+
+You can pass these options when creating routes (all of them are optional):
+
+| Parameter | Examples | Description |
+| --- | --- | --- |
+| `rvn.autoSession` | `true` \|  `'test'` \| `['local', 'external']` | Whether to open sessions automatically for specific database instances. It can be a boolean to target the global instance, or a string/array of strings to target one or multiple named instances. Please check [Name option](#name-option) for more information. |
+
+## Examples
+
+### Basic example
 
 ```javascript
 import Fastify from 'fastify'
 import plugin from 'fastify-ravendb'
 
-export class Person {
+class Person {
   constructor(name) {
     this.name = name
   }
 }
+
+const routeOptions = { rvn: { autoSession: true } }
 
 const start = async () => {
   const fastify = Fastify({ logger: true })
@@ -54,19 +72,16 @@ const start = async () => {
     databaseName: 'test'
   })
 
-  fastify.post('/people', async (req, reply) => {
+  fastify.post('/people', routeOptions, async (req, reply) => {
     const person = new Person(req.body.name)
 
-    const session = fastify.rvn.openSession()
-    await session.store(person, Person)
-    await session.saveChanges()
+    await req.rvn.store(person)
 
     reply.send(person)
   })
 
-  fastify.get('/people/:id', async (req, reply) => {
-    const session = fastify.rvn.openSession()
-    const person = await session.load(`people/${req.params.id}`, Person)
+  fastify.get('/people/:id', routeOptions, async (req, reply) => {
+    const person = await req.rvn.load(`people/${req.params.id}`, Person)
 
     reply.send(person)
   })
@@ -77,7 +92,7 @@ const start = async () => {
 start()
 ```
 
-## Advanced examples
+### Advanced examples
 
 More advanced examples are provided in the [examples folder](examples/).
 
@@ -105,7 +120,7 @@ await fastify.register(plugin, {
 
 ## Docker
 
-A RavenDB Docker container with a database fixture named `test` has been provided for convenience and for using the advanced examples.
+A RavenDB Docker container with a database fixture named `test` has been provided for running tests which require a real database and for using the advanced examples.
 
 ### Run
 
@@ -156,6 +171,12 @@ If port `8080` is already allocated in your system, you can change the `config.d
 ### Reset fixtures
 
 If at some point you want to reset the fixtures you can remove the container and start again.
+
+## Testing
+
+In order to run the tests first you'll need to start the provided Docker container. Please check [Docker](#docker) for more information.
+
+While the container is up you can run the tests with `npm test`.
 
 ## License
 

--- a/examples/lib/classes.js
+++ b/examples/lib/classes.js
@@ -1,0 +1,12 @@
+export class Category {
+  constructor(name, description) {
+    this.name = name
+    this.description = description
+  }
+}
+
+export class Person {
+  constructor(name) {
+    this.name = name
+  }
+}

--- a/examples/lib/constants.js
+++ b/examples/lib/constants.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 
 // Workaround for ESLint not being able to parse "assert { type: 'json' }" when importing modules
-const pjsonUrl = new URL('../package.json', import.meta.url)
+const pjsonUrl = new URL('../../package.json', import.meta.url)
 const pjson = JSON.parse(readFileSync(pjsonUrl))
 
 export const port = 3000

--- a/examples/multiple-dbs-with-session.js
+++ b/examples/multiple-dbs-with-session.js
@@ -4,7 +4,7 @@ import plugin from '../index.js'
 import { Category, Person } from './lib/classes.js'
 import { port, url, databaseName, categories, people } from './lib/constants.js'
 
-const routeOptions = { rvnSession: true }
+const routeOptions = { rvn: { autoSession: ['local', 'remote'] } }
 
 const start = async () => {
   const fastify = Fastify({ logger: true })

--- a/examples/multiple-dbs-with-session.js
+++ b/examples/multiple-dbs-with-session.js
@@ -16,6 +16,8 @@ class Person {
   }
 }
 
+const routeOptions = { rvnSession: true }
+
 const start = async () => {
   const fastify = Fastify({ logger: true })
   await fastify.register(plugin, { name: 'local', url, databaseName })
@@ -25,19 +27,16 @@ const start = async () => {
     databaseName
   })
 
-  fastify.post(`/${categories}`, async (req, reply) => {
+  fastify.post(`/${categories}`, routeOptions, async (req, reply) => {
     const category = new Category(req.body.name, req.body.description)
 
-    const session = fastify.rvn.remote.openSession()
-    await session.store(category)
-    await session.saveChanges()
+    await req.rvn.remote.store(category)
 
     reply.send(category)
   })
 
-  fastify.get(`/${categories}/:id`, async (req, reply) => {
-    const session = fastify.rvn.remote.openSession()
-    const category = await session.load(
+  fastify.get(`/${categories}/:id`, routeOptions, async (req, reply) => {
+    const category = await req.rvn.remote.load(
       `${categories}/${req.params.id}`,
       Category
     )
@@ -45,19 +44,19 @@ const start = async () => {
     reply.send(category)
   })
 
-  fastify.post(`/${people}`, async (req, reply) => {
+  fastify.post(`/${people}`, routeOptions, async (req, reply) => {
     const person = new Person(req.body.name)
 
-    const session = fastify.rvn.local.openSession()
-    await session.store(person)
-    await session.saveChanges()
+    await req.rvn.local.store(person)
 
     reply.send(person)
   })
 
-  fastify.get(`/${people}/:id`, async (req, reply) => {
-    const session = fastify.rvn.local.openSession()
-    const person = await session.load(`${people}/${req.params.id}`, Person)
+  fastify.get(`/${people}/:id`, routeOptions, async (req, reply) => {
+    const person = await req.rvn.local.load(
+      `${people}/${req.params.id}`,
+      Person
+    )
 
     reply.send(person)
   })

--- a/examples/multiple-dbs-with-session.js
+++ b/examples/multiple-dbs-with-session.js
@@ -1,20 +1,8 @@
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-import { port, url, databaseName, categories, people } from './constants.js'
-
-class Category {
-  constructor(name, description) {
-    this.Name = name
-    this.Description = description
-  }
-}
-
-class Person {
-  constructor(name) {
-    this.Name = name
-  }
-}
+import { Category, Person } from './lib/classes.js'
+import { port, url, databaseName, categories, people } from './lib/constants.js'
 
 const routeOptions = { rvnSession: true }
 

--- a/examples/multiple-dbs.js
+++ b/examples/multiple-dbs.js
@@ -1,20 +1,8 @@
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-import { port, url, databaseName, categories, people } from './constants.js'
-
-class Category {
-  constructor(name, description) {
-    this.Name = name
-    this.Description = description
-  }
-}
-
-class Person {
-  constructor(name) {
-    this.Name = name
-  }
-}
+import { Category, Person } from './lib/classes.js'
+import { port, url, databaseName, categories, people } from './lib/constants.js'
 
 const start = async () => {
   const fastify = Fastify({ logger: true })

--- a/examples/object-literals.js
+++ b/examples/object-literals.js
@@ -1,7 +1,7 @@
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-import { port, url, databaseName, people } from './constants.js'
+import { port, url, databaseName, people } from './lib/constants.js'
 
 const start = async () => {
   const findCollectionNameForObjectLiteral = e => e._collection

--- a/examples/object-literals.js
+++ b/examples/object-literals.js
@@ -15,7 +15,7 @@ const start = async () => {
 
   fastify.post(`/${people}`, async (req, reply) => {
     const person = {
-      Name: req.body.name,
+      name: req.body.name,
       _collection: people
     }
 

--- a/examples/single-db-with-session.js
+++ b/examples/single-db-with-session.js
@@ -1,13 +1,8 @@
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-import { port, url, databaseName, people } from './constants.js'
-
-class Person {
-  constructor(name) {
-    this.Name = name
-  }
-}
+import { Person } from './lib/classes.js'
+import { port, url, databaseName, people } from './lib/constants.js'
 
 const routeOptions = { rvnSession: true }
 

--- a/examples/single-db-with-session.js
+++ b/examples/single-db-with-session.js
@@ -4,7 +4,7 @@ import plugin from '../index.js'
 import { Person } from './lib/classes.js'
 import { port, url, databaseName, people } from './lib/constants.js'
 
-const routeOptions = { rvnSession: true }
+const routeOptions = { rvn: { autoSession: true } }
 
 const start = async () => {
   const fastify = Fastify({ logger: true })

--- a/examples/single-db-with-session.js
+++ b/examples/single-db-with-session.js
@@ -9,23 +9,22 @@ class Person {
   }
 }
 
+const routeOptions = { rvnSession: true }
+
 const start = async () => {
   const fastify = Fastify({ logger: true })
   await fastify.register(plugin, { url, databaseName })
 
-  fastify.post(`/${people}`, async (req, reply) => {
+  fastify.post(`/${people}`, routeOptions, async (req, reply) => {
     const person = new Person(req.body.name)
 
-    const session = fastify.rvn.openSession()
-    await session.store(person)
-    await session.saveChanges()
+    await req.rvn.store(person)
 
     reply.send(person)
   })
 
-  fastify.get(`/${people}/:id`, async (req, reply) => {
-    const session = fastify.rvn.openSession()
-    const person = await session.load(`${people}/${req.params.id}`, Person)
+  fastify.get(`/${people}/:id`, routeOptions, async (req, reply) => {
+    const person = await req.rvn.load(`${people}/${req.params.id}`, Person)
 
     reply.send(person)
   })

--- a/examples/single-db.js
+++ b/examples/single-db.js
@@ -1,13 +1,8 @@
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-import { port, url, databaseName, people } from './constants.js'
-
-class Person {
-  constructor(name) {
-    this.Name = name
-  }
-}
+import { Person } from './lib/classes.js'
+import { port, url, databaseName, people } from './lib/constants.js'
 
 const start = async () => {
   const fastify = Fastify({ logger: true })

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from 'fastify';
-import { IDocumentStore, IStoreAuthOptions } from 'ravendb'
+import { IDocumentSession, IDocumentStore, IStoreAuthOptions } from 'ravendb'
 
 type IOptions = {
   /**
@@ -28,14 +28,26 @@ type IOptions = {
   findCollectionNameForObjectLiteral?: (entity: object) => string;
 }
 
+type IRouteOptions = {
+  autoSession?: boolean | string | string[];
+}
+
 declare const plugin: FastifyPluginCallback<IOptions>;
 
 declare module 'fastify' {
   export interface FastifyInstance {
     rvn: IDocumentStore & Record<string, IDocumentStore>;
   }
+
+  export interface FastifyRequest {
+    rvn?: IDocumentSession & Record<string, IDocumentSession>;
+  }
+
+  export interface RouteShorthandOptions {
+    rvn?: IRouteOptions;
+  }
 }
 
-export { plugin, IOptions };
+export { plugin, IOptions, IRouteOptions };
 
 export default plugin;

--- a/index.js
+++ b/index.js
@@ -35,7 +35,16 @@ const fastifyRaven = async (fastify, options) => {
   })
 
   fastify.addHook('onRoute', routeOptions => {
-    if (!routeOptions.rvnSession) {
+    const autoSession =
+      routeOptions && routeOptions.rvn && routeOptions.rvn.autoSession
+
+    if (
+      !autoSession ||
+      (name && autoSession === true) ||
+      (typeof autoSession === 'string' && autoSession !== name) ||
+      (Array.isArray(routeOptions.rvn.autoSession) &&
+        !routeOptions.rvn.autoSession.includes(name))
+    ) {
       return
     }
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ import {
   addDocumentStore,
   addHandler,
   addRequestSession,
+  autoSessionTargetsGlobalInstance,
+  autoSessionTargetsNamedInstance,
   getRequestSession
 } from './lib/helpers.js'
 
@@ -35,15 +37,14 @@ const fastifyRaven = async (fastify, options) => {
   })
 
   fastify.addHook('onRoute', routeOptions => {
-    const autoSession =
-      routeOptions?.rvn?.autoSession
+    const autoSession = routeOptions?.rvn?.autoSession
 
     if (
       !autoSession ||
-      (name && autoSession === true) ||
-      (typeof autoSession === 'string' && autoSession !== name) ||
-      (Array.isArray(routeOptions.rvn.autoSession) &&
-        !routeOptions.rvn.autoSession.includes(name))
+      !(
+        autoSessionTargetsGlobalInstance(autoSession, name) ||
+        autoSessionTargetsNamedInstance(autoSession, name)
+      )
     ) {
       return
     }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const fastifyRaven = async (fastify, options) => {
 
   fastify.addHook('onRoute', routeOptions => {
     const autoSession =
-      routeOptions && routeOptions.rvn && routeOptions.rvn.autoSession
+      routeOptions?.rvn?.autoSession
 
     if (
       !autoSession ||

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
-import { readFileSync } from 'fs'
 import { DocumentStore } from 'ravendb'
 import fp from 'fastify-plugin'
 
-// Workaround for ESLint not being able to parse "assert { type: 'json' }" when importing modules
-const pjsonUrl = new URL('./package.json', import.meta.url)
-const { name: packageName } = JSON.parse(readFileSync(pjsonUrl))
+import { PACKAGE_NAME } from './lib/constants.js'
+import {
+  addDocumentStore,
+  addHandler,
+  addRequestSession,
+  getRequestSession
+} from './lib/helpers.js'
 
 const fastifyRaven = async (fastify, options) => {
   const {
@@ -17,29 +20,7 @@ const fastifyRaven = async (fastify, options) => {
 
   const documentStore = new DocumentStore(url, databaseName, authOptions)
 
-  if (name) {
-    if (documentStore[name]) {
-      throw new Error(`${packageName} '${name}' is a reserved keyword`)
-    } else if (!fastify.rvn) {
-      fastify.decorate('rvn', Object.create(null))
-    } else if (fastify.rvn[name]) {
-      throw new Error(
-        `${packageName} '${name}' instance name has already been registered`
-      )
-    }
-
-    Object.assign(fastify.rvn, { [name]: documentStore })
-  } else {
-    if (fastify.rvn) {
-      if (fastify.rvn.initialize) {
-        throw new Error(`${packageName} has already been registered`)
-      }
-
-      Object.assign(fastify.rvn, documentStore)
-    } else {
-      fastify.decorate('rvn', documentStore)
-    }
-  }
+  addDocumentStore(fastify, documentStore, name)
 
   if (findCollectionNameForObjectLiteral instanceof Function) {
     Object.assign(documentStore.conventions, {
@@ -52,9 +33,36 @@ const fastifyRaven = async (fastify, options) => {
   fastify.addHook('onClose', () => {
     documentStore.dispose()
   })
+
+  fastify.addHook('onRoute', routeOptions => {
+    if (!routeOptions.rvnSession) {
+      return
+    }
+
+    if (!fastify.hasRequestDecorator('rvn')) {
+      fastify.decorateRequest('rvn', null)
+    }
+
+    const preHandler = async req => {
+      const session = documentStore.openSession()
+
+      addRequestSession(req, session, name)
+    }
+
+    const onResponse = async req => {
+      const session = getRequestSession(req, name)
+
+      if (Object.keys(session.advanced.whatChanged()).length) {
+        await session.saveChanges()
+      }
+    }
+
+    routeOptions.preHandler = addHandler(routeOptions.preHandler, preHandler)
+    routeOptions.onResponse = addHandler(routeOptions.onResponse, onResponse)
+  })
 }
 
 export default fp(fastifyRaven, {
   fastify: '4.x',
-  name: packageName
+  name: PACKAGE_NAME
 })

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs'
+
+// Workaround for ESLint not being able to parse "assert { type: 'json' }" when importing modules
+const pjsonUrl = new URL('../package.json', import.meta.url)
+const { name } = JSON.parse(readFileSync(pjsonUrl))
+
+export const DOCUMENT_STORE_CHECK_KEY = 'initialize'
+export const PACKAGE_NAME = name

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -52,5 +52,12 @@ export const addRequestSession = (req, session, name) => {
   }
 }
 
+export const autoSessionTargetsGlobalInstance = (autoSession, instanceName) =>
+  autoSession === true && !instanceName
+
+export const autoSessionTargetsNamedInstance = (autoSession, instanceName) =>
+  (typeof autoSession === 'string' && autoSession === instanceName) ||
+  (Array.isArray(autoSession) && autoSession.includes(instanceName))
+
 export const getRequestSession = (req, name) =>
   typeof name === 'string' ? req.rvn[name] : req.rvn

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -30,7 +30,7 @@ export const addDocumentStore = (fastify, documentStore, name) => {
 
 export const addHandler = (existingHandler, newHandler) => {
   if (Array.isArray(existingHandler)) {
-    return [...existingHandler, newHandler]
+    return existingHandler.concat(newHandler)
   } else if (typeof existingHandler === 'function') {
     return [existingHandler, newHandler]
   } else {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -43,18 +43,12 @@ export const addRequestSession = (req, session, name) => {
     if (Object.prototype.hasOwnProperty.call(session, name)) {
       throw new Error(`${PACKAGE_NAME} '${name}' is a session reserved keyword`)
     } else if (!req.rvn) {
-      // Failing to set the correct prototype here will result in missing functions
-      // if we create an anonymous instance session after a named one
-      req.rvn = Object.create(session)
+      req.rvn = Object.create(null)
     }
 
     req.rvn[name] = session
   } else {
-    if (req.rvn) {
-      Object.assign(req.rvn, session)
-    } else {
-      req.rvn = session
-    }
+    req.rvn = session
   }
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,62 @@
+import { DOCUMENT_STORE_CHECK_KEY, PACKAGE_NAME } from './constants.js'
+
+export const addDocumentStore = (fastify, documentStore, name) => {
+  if (name) {
+    if (name in documentStore) {
+      throw new Error(
+        `${PACKAGE_NAME} '${name}' is an instance reserved keyword`
+      )
+    } else if (!fastify.rvn) {
+      fastify.decorate('rvn', Object.create(null))
+    } else if (name in fastify.rvn) {
+      throw new Error(
+        `${PACKAGE_NAME} '${name}' instance name has already been registered`
+      )
+    }
+
+    Object.assign(fastify.rvn, { [name]: documentStore })
+  } else {
+    if (fastify.rvn) {
+      if (DOCUMENT_STORE_CHECK_KEY in fastify.rvn) {
+        throw new Error(`${PACKAGE_NAME} has already been registered`)
+      }
+
+      Object.assign(fastify.rvn, documentStore)
+    } else {
+      fastify.decorate('rvn', documentStore)
+    }
+  }
+}
+
+export const addHandler = (existingHandler, newHandler) => {
+  if (Array.isArray(existingHandler)) {
+    return [...existingHandler, newHandler]
+  } else if (typeof existingHandler === 'function') {
+    return [existingHandler, newHandler]
+  } else {
+    return [newHandler]
+  }
+}
+
+export const addRequestSession = (req, session, name) => {
+  if (name) {
+    if (Object.prototype.hasOwnProperty.call(session, name)) {
+      throw new Error(`${PACKAGE_NAME} '${name}' is a session reserved keyword`)
+    } else if (!req.rvn) {
+      // Failing to set the correct prototype here will result in missing functions
+      // if we create an anonymous instance session after a named one
+      req.rvn = Object.create(session)
+    }
+
+    req.rvn[name] = session
+  } else {
+    if (req.rvn) {
+      Object.assign(req.rvn, session)
+    } else {
+      req.rvn = session
+    }
+  }
+}
+
+export const getRequestSession = (req, name) =>
+  typeof name === 'string' ? req.rvn[name] : req.rvn

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs'
+
+// Workaround for ESLint not being able to parse "assert { type: 'json' }" when importing modules
+const pjsonUrl = new URL('../package.json', import.meta.url)
+const pjson = JSON.parse(readFileSync(pjsonUrl))
+
+export const url = `http://localhost:${pjson.config.docker.port}`
+export const databaseName = 'test'

--- a/test/register.test.js
+++ b/test/register.test.js
@@ -4,9 +4,7 @@ import { DocumentStore } from 'ravendb'
 import Fastify from 'fastify'
 
 import plugin from '../index.js'
-
-const url = 'http://dummy.db'
-const databaseName = 'test'
+import { url, databaseName } from './constants.js'
 
 test('Should register with no name', async t => {
   const fastify = Fastify()

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1,0 +1,161 @@
+import sinon from 'sinon'
+import { test } from 'tap'
+import { DocumentSession } from 'ravendb'
+import Fastify from 'fastify'
+
+import plugin from '../index.js'
+import { url, databaseName } from './constants.js'
+
+const routeOptions = { rvnSession: true }
+
+class Person {
+  constructor(name) {
+    this.Name = name
+  }
+}
+
+test('Should not create any session if not enabled for route', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName })
+
+  fastify.get('/', async req => {
+    t.notHas(req, 'rvn')
+  })
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})
+
+test('Should create a session with no name', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName })
+
+  fastify.get('/', routeOptions, async req => {
+    t.hasProp(req, 'rvn')
+    t.ok(req.rvn instanceof DocumentSession)
+  })
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})
+
+test('Should create a session with name', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName, name: 'extra' })
+
+  fastify.get('/', routeOptions, async req => {
+    t.hasProp(req.rvn, 'extra')
+    t.ok(req.rvn.extra instanceof DocumentSession)
+  })
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})
+
+test('Should create a session both with no name and name', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName })
+  await fastify.register(plugin, { url, databaseName, name: 'extra' })
+
+  fastify.get('/', routeOptions, async req => {
+    t.hasProp(req, 'rvn')
+    t.ok(req.rvn instanceof DocumentSession)
+    t.hasProp(req.rvn, 'extra')
+    t.ok(req.rvn.extra instanceof DocumentSession)
+  })
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})
+
+test('Should create a session both with no name and name (same as previous, but in reverse order)', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName, name: 'extra' })
+  await fastify.register(plugin, { url, databaseName })
+
+  fastify.get('/', routeOptions, async req => {
+    t.hasProp(req, 'rvn')
+    t.ok(req.rvn instanceof DocumentSession)
+    t.hasProp(req.rvn, 'extra')
+    t.ok(req.rvn.extra instanceof DocumentSession)
+  })
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})
+
+test('Should return 500 when creating a session with a reserved name', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, {
+    url,
+    databaseName,
+    name: 'maxNumberOfRequestsPerSession'
+  })
+
+  fastify.get(`/`, routeOptions, async () => {})
+
+  const res = await fastify.inject({ method: 'GET', url: '/' })
+
+  t.equal(res.statusCode, 500)
+  t.match(res.json().message, 'is a session reserved keyword')
+
+  await fastify.close()
+})
+
+test('Should save changes after request', async () => {
+  let saveChangesSpy = null
+
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName })
+
+  fastify.post(`/`, routeOptions, async (req, reply) => {
+    saveChangesSpy = sinon.spy(req.rvn, 'saveChanges')
+
+    const person = new Person(req.body.name)
+
+    await req.rvn.store(person)
+
+    reply.send(person)
+  })
+
+  await fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: { name: 'John Doe' }
+  })
+
+  sinon.assert.calledOnce(saveChangesSpy)
+
+  await fastify.close()
+})
+
+test('Should create a session respecting existing handlers', async t => {
+  const fastify = Fastify()
+
+  await fastify.register(plugin, { url, databaseName })
+
+  fastify.get(
+    '/',
+    { ...routeOptions, preHandler: async () => {} },
+    async req => {
+      t.ok(Array.isArray(req.context.preHandler))
+      t.equal(req.context.preHandler.length, 2)
+    }
+  )
+
+  await fastify.inject({ method: 'GET', url: '/' })
+
+  await fastify.close()
+})

--- a/test/types/imports.test-d.ts
+++ b/test/types/imports.test-d.ts
@@ -2,4 +2,5 @@ import defaultPluginImport from '../../index';
 import {
     plugin as namedPluginImport,
     IOptions,
+    IRouteOptions,
 } from '../../index';

--- a/test/types/session.test-d.ts
+++ b/test/types/session.test-d.ts
@@ -1,0 +1,51 @@
+import fastify from 'fastify'
+
+import plugin from '../../index'
+
+class Category {
+  name: string
+  description: string
+
+  constructor(name: string, description: string) {
+    this.name = name
+    this.description = description
+  }
+}
+
+class Person {
+  name: string
+
+  constructor(name: string) {
+    this.name = name
+  }
+}
+
+const app = fastify()
+
+app.register(plugin, { url: 'http://localhost', databaseName: 'test' })
+app.register(plugin, { url: 'http://localhost', databaseName: 'test', name: 'categories' })
+app.register(plugin, { url: 'http://localhost', databaseName: 'test', name: 'people' })
+
+app.post('/global', { rvn: { autoSession: true } }, async (req, reply) => {
+  const test = { name: 'test' }
+
+  await req.rvn?.store(test)
+
+  reply.send(test)
+})
+
+app.post('/people', { rvn: { autoSession: 'people' } }, async (req, reply) => {
+  const person = new Person('Jane Doe')
+
+  await req.rvn?.people?.store(person)
+
+  reply.send(person)
+})
+
+app.post('/categories', { rvn: { autoSession: ['categories', 'people'] } }, async (req, reply) => {
+  const category = new Category('Books', 'Novels, biographies, dictionaries, manuals...')
+
+  await req.rvn?.categories?.store(category)
+
+  reply.send(category)
+})


### PR DESCRIPTION
This PR adds the ability to automatically open and handle RavenDB sessions for specific routes.

The user can provide a `rvn.autoSession` route option that can be a boolean to target the global RavenDB instance, or a string/array of strings to target one or multiple named RavenDB instances.

If the `autoSession` parameter targets any existing RavenDB instance, a new session will be open `onRequest` and any pending changes will be saved `onResponse`.

The user can also access the session via a request decorator (`req.rvn` for global instance sessions or `req.rvn[name]` for named instance sessions) and use it like a standard RavenDB client session.