### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "fastify": "^4.5.3",
-        "husky": "^9.0.6",
+        "husky": "^9.0.11",
         "lint-staged": "^15.0.2",
         "prettier": "^3.0.1",
         "ravendb": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docker:url": "echo You can access RavenDB Management Studio on http://localhost:$npm_package_config_docker_port",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "npm run test:unit && npm run test:types",
     "test:types": "tsd",
     "test:unit": "c8 --100 tap -J --no-coverage test/*.test.js"
@@ -61,7 +61,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "fastify": "^4.5.3",
-    "husky": "^9.0.6",
+    "husky": "^9.0.11",
     "lint-staged": "^15.0.2",
     "prettier": "^3.0.1",
     "ravendb": "^5.2.7",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)