### PR TITLE
chore(deps): consolidate remaining dependabot updates

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -16,4 +16,4 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: nearform-actions/github-action-notify-release@v1
+      - uses: nearform-actions/github-action-notify-release@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5142,9 +5142,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7212,9 +7212,9 @@
       }
     },
     "flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "foreground-child": {
@@ -8915,9 +8915,9 @@
       "peer": true
     },
     "undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true
     },
     "undici-types": {


### PR DESCRIPTION
Consolidates the remaining open Dependabot PRs into a single reviewable change. The npm updates were re-derived (packages bumped, lockfile regenerated) rather than merged, so the dependency graph stays coherent.

> Note: most of the originally open Dependabot PRs (ws, brace-expansion, fast-uri/fastify, actions/checkout v7, actions/setup-node v7) were merged into `master` directly while this was being prepared. This PR folds in the three that were still open.

## Included updates

### npm (dev / transitive)
| Package | From | To | Bump | Supersedes | Status |
|---------|------|----|------|------------|--------|
| flatted | 3.3.2 | 3.4.2 | minor | #470 | ✅ pass |
| undici | 6.21.3 | 6.27.0 | minor | #468 | ✅ pass |

### GitHub Actions
| Action | From | To | Bump | Supersedes | Status |
|--------|------|----|------|------------|--------|
| nearform-actions/github-action-notify-release | v1 | v2 | major | #474 | ✅ pass |

## Verification
- `npm ci` (lock resolves): ✅
- `npm run lint`: ✅
- `npm run test:types` (tsd): ✅
- `npm run test:unit` (against a local RavenDB): ✅ 16/16, 100% coverage

## Notes
- No source changes — dependency lockfile + one workflow file only.
- #464 (human-authored tstyche migration) is out of scope and left untouched.
